### PR TITLE
Fix itinerary navigation

### DIFF
--- a/braziltrip_22_day_itinerary.html
+++ b/braziltrip_22_day_itinerary.html
@@ -440,7 +440,7 @@
 
                 button.classList.add('active');
                 button.setAttribute('aria-pressed', 'true');
-                document.querySelector(`[data-day="${day}"]`).classList.add('active');
+                document.querySelector(`.day-content[data-day="${day}"]`).classList.add('active');
 
                 const progressPercentage = (day / dayButtons.length) * 100;
                 progressFill.style.width = `${progressPercentage.toFixed(2)}%`;


### PR DESCRIPTION
## Summary
- fix JS selector to highlight the correct day content in the 22‑day itinerary

## Testing
- `node --version`
- `node test.js` *(fails: scrollIntoView not implemented but confirms day2 becomes active)*

------
https://chatgpt.com/codex/tasks/task_e_6842ee0b88148327a8ba440d4c001135